### PR TITLE
Make the SSH Deploy Jobs Reusable

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -1,0 +1,37 @@
+# https://github.com/marketplace/actions/web-deploy-anything
+---
+on:
+  workflow_call:
+    inputs:
+      dry-run:
+        required: false
+        type: string
+    secrets:
+        WEBSITE_SSH_PRIVATE_KEY:
+          required: true
+
+name: Publish Website via SSH  # TODO: make this reuse pr-validate.yml
+jobs:
+  web-deploy:
+    name: Deploy Website During Merge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Latest Files
+        uses: actions/checkout@v3
+
+      - name: Setup Custom SSH Config  # Necessary because server's OpenSSH 5.3 doesn't natively support RSA
+        run: >
+          mkdir ~/.ssh &&
+          echo -e "Host *\n    HostKeyAlgorithms +ssh-rsa\n    PubkeyAcceptedAlgorithms +ssh-rsa" > ~/.ssh/config
+
+      - name: Final Publish via rsync
+        uses: SamKirkland/web-deploy@v1
+        with:
+          target-server: server234.web-hosting.com
+          remote-user: davivirc
+          private-ssh-key: ${{ secrets.WEBSITE_SSH_PRIVATE_KEY }}
+          ssh-port: 21098
+          destination-path: ~/public_html
+          rsync-options: >
+            -v ${{ inputs.dry-run }} --archive --itemize-changes --delete-after --human-readable --stats
+            --exclude=.git* --exclude=.git/ --exclude-from=.gitignore

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -7,10 +7,10 @@ on:
         required: false
         type: string
     secrets:
-        WEBSITE_SSH_PRIVATE_KEY:
-          required: true
+      WEBSITE_SSH_PRIVATE_KEY:
+        required: true
 
-name: Publish Website via SSH  # TODO: make this reuse pr-validate.yml
+name: Publish Website via SSH
 jobs:
   web-deploy:
     name: Deploy Website During Merge

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -4,26 +4,8 @@ on: pull_request
 
 name: Test Publishing via SSH  # DOES NOT DEPLOY CHANGES!
 jobs:
-  web-deploy:
-    name: Deploy Website During PR
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get Latest Files
-        uses: actions/checkout@v3
-
-      - name: Setup Custom SSH Config  # Necessary because server's OpenSSH 5.3 doesn't natively support RSA
-        run: >
-          mkdir ~/.ssh &&
-          echo -e "Host *\n    HostKeyAlgorithms +ssh-rsa\n    PubkeyAcceptedAlgorithms +ssh-rsa" > ~/.ssh/config
-
-      - name: Test Publish via rsync
-        uses: SamKirkland/web-deploy@v1
-        with:
-          target-server: server234.web-hosting.com
-          remote-user: davivirc
-          private-ssh-key: ${{ secrets.WEBSITE_SSH_PRIVATE_KEY }}
-          ssh-port: 21098
-          destination-path: ~/public_html
-          rsync-options: >
-            -v --dry-run --archive --itemize-changes --delete-after --human-readable --stats
-            --exclude=.git* --exclude=.git/ --exclude-from=.gitignore
+  call-workflow-passing-data:
+    uses: ./.github/workflows/pr-merge.yml
+    with:
+      dry-run: --dry-run
+    secrets: inherit

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -5,28 +5,9 @@ on:
     branches:
       - master
 
-name: Publish Website via SSH  # TODO: make this reuse pr-validate.yml
+name: Test Publishing via SSH  # DOES NOT DEPLOY CHANGES!
 jobs:
-  web-deploy:
-    name: Deploy Website During Merge
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get Latest Files
-        uses: actions/checkout@v3
-
-      - name: Setup Custom SSH Config  # Necessary because server's OpenSSH 5.3 doesn't natively support RSA
-        run: >
-          mkdir ~/.ssh &&
-          echo -e "Host *\n    HostKeyAlgorithms +ssh-rsa\n    PubkeyAcceptedAlgorithms +ssh-rsa" > ~/.ssh/config
-
-      - name: Final Publish via rsync
-        uses: SamKirkland/web-deploy@v1
-        with:
-          target-server: server234.web-hosting.com
-          remote-user: davivirc
-          private-ssh-key: ${{ secrets.WEBSITE_SSH_PRIVATE_KEY }}
-          ssh-port: 21098
-          destination-path: ~/public_html
-          rsync-options: >
-            -v --archive --itemize-changes --delete-after --human-readable --stats
-            --exclude=.git* --exclude=.git/ --exclude-from=.gitignore
+  call-workflow-passing-data:
+    uses: ./.github/workflows/pr-merge.yml
+    # Providing nothing to dry-run, since this is the real publish!
+    secrets: inherit


### PR DESCRIPTION
The code is so similar between the PR and the Merge Deploy pipelines, might as well make them reusable to avoid duplication errors in the future